### PR TITLE
Decouple Git Cloning form Template Class

### DIFF
--- a/facio/config.py
+++ b/facio/config.py
@@ -1,5 +1,10 @@
-#!/usr/bin/env python
-# encoding: utf-8
+"""
+facio.config
+------------
+
+Setsmup variables and configuration for Facio from command line and / or
+a configuration file.
+"""
 
 import ConfigParser
 import os

--- a/facio/install.py
+++ b/facio/install.py
@@ -1,7 +1,13 @@
-#!/usr/bin/env python
-# encoding: utf-8
+"""
+facio.install
+-------------
+
+This experimental. This should install a python template onto the path
+in develop mode.
+"""
 
 import os
+
 from shutil import rmtree
 from subprocess import Popen, PIPE, STDOUT
 

--- a/facio/opts.py
+++ b/facio/opts.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
-# encoding: utf-8
+"""
+facio.opts
+----------
 
-'''
 Allows for required=True to be parsed into options list, taken from
 http://docs.python.org/release/2.3/lib/optparse-extending-examples.html.
-'''
+"""
 
 import optparse
 
@@ -16,7 +16,7 @@ class Option(optparse.Option):
         if self.required and not self.takes_value():
             raise optparse.OptionError(
                 "required flag set for option that doesn't take a value",
-                 self)
+                self)
 
     # Make sure _check_required() is called from the constructor!
     CHECK_METHODS = optparse.Option.CHECK_METHODS + [_check_required]
@@ -34,8 +34,8 @@ class OptionParser(optparse.OptionParser):
 
     def check_values(self, values, args):
         for option in self.option_list:
-            if (isinstance(option, Option) and
-                option.required and
-                not self.option_seen.has_key(option)):
+            if (isinstance(option, Option)
+                    and option.required
+                    and not option in self.option_seen):
                 self.error("%s is a required option." % option)
         return (values, args)

--- a/facio/template.py
+++ b/facio/template.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python
+"""
+facio.template
+--------------
+
+Process the users template using Jninja2 rendering it out into the current
+working directory.
+"""
 
 import os
 import re

--- a/facio/template.py
+++ b/facio/template.py
@@ -88,8 +88,6 @@ class Template(object):
                 }[vcs]
 
         if vcs_cls:
-            import ipdb
-            ipdb.set_trace()
             vcs_cls.clone()
             self.is_vcs_template = True
             self.config.template = vcs_cls.tmp_dir

--- a/facio/template.py
+++ b/facio/template.py
@@ -85,18 +85,18 @@ class Template(object):
     def vcs(self):
         '''Detect VCS template, if True clone into temp dir.'''
 
-        vcs_cls = None
+        self.vcs_cls = None
         supported_vcs = ['git', ]
         for vcs in supported_vcs:
             if self.config.template.startswith('%s+' % vcs):
-                vcs_cls = {
+                self.vcs_cls = {
                     'git': Git(self.config.template),
                 }[vcs]
 
-        if vcs_cls:
-            vcs_cls.clone()
+        if self.vcs_cls:
+            self.vcs_cls.clone()
             self.is_vcs_template = True
-            self.config.template = vcs_cls.tmp_dir
+            self.config.template = self.vcs_cls.tmp_dir
 
     def copy_template(self):
         '''Moves template into current working dir.'''

--- a/facio/vcs/git.py
+++ b/facio/vcs/git.py
@@ -5,6 +5,11 @@ facio.vcs.git
 Git Version Control Template Cloning.
 """
 
+import os
+import tempfile
+
+from shutil import rmtree
+
 
 class Git(object):
 
@@ -17,5 +22,22 @@ class Git(object):
             self._repo = self.template_path.replace('git+', '')
         return self._repo
 
+    def _make_tmp_dir(self):
+        self.tmp_dir = tempfile.mkdtemp(suffix='facio')
+
     def clone(self):
-        pass
+        try:
+            from git import Repo
+        except ImportError:
+            raise Exception  # TODO: Custom exception
+
+        try:
+            repo = Repo.init(self.tmp_dir)
+            repo.create_remote('origin', self.repo)
+            origin = repo.remotes.origin
+            origin.fetch()
+            origin.pull('master')  # TODO: Branch prompt to the user
+        except Exception:
+            raise Exception  # TODO: Custom exception
+
+        rmtree(os.path.join(self.tmp_dir, '.git'))

--- a/facio/vcs/git.py
+++ b/facio/vcs/git.py
@@ -1,0 +1,21 @@
+"""
+facio.vcs.git
+-------------
+
+Git Version Control Template Cloning.
+"""
+
+
+class Git(object):
+
+    def __init__(self, template_path):
+        self.template_path = template_path
+
+    @property
+    def repo(self):
+        if not hasattr(self, '_repo'):
+            self._repo = self.template_path.replace('git+', '')
+        return self._repo
+
+    def clone(self):
+        pass

--- a/facio/vcs/git_vcs.py
+++ b/facio/vcs/git_vcs.py
@@ -1,6 +1,6 @@
 """
-facio.vcs.git
--------------
+facio.vcs.git_vcs
+-----------------
 
 Git Version Control Template Cloning.
 """
@@ -31,6 +31,7 @@ class Git(object):
         except ImportError:
             raise Exception  # TODO: Custom exception
 
+        self._make_tmp_dir()
         try:
             repo = Repo.init(self.tmp_dir)
             repo.create_remote('origin', self.repo)

--- a/facio/vcs/git_vcs.py
+++ b/facio/vcs/git_vcs.py
@@ -13,6 +13,8 @@ from shutil import rmtree
 
 class Git(object):
 
+    tmp_dir = None
+
     def __init__(self, template_path):
         self.template_path = template_path
 

--- a/facio/virtualenv.py
+++ b/facio/virtualenv.py
@@ -1,7 +1,13 @@
-#!/usr/bin/env python
-# encoding: utf-8
+"""
+facio.virtualenv
+----------------
+
+This is experimental. This should create a python virtual environment for the
+project.
+"""
 
 import os
+
 from subprocess import Popen, PIPE, STDOUT
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -73,17 +73,15 @@ class TemplateTests(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     @patch('tempfile.mkdtemp', return_value=True)
-    @patch('facio.Template.git_clone', return_value=True)
-    def should_detect_git_repo(self, mock_git_clone, mock_tempfile,
+    @patch('facio.vcs.git_vcs.Git.clone', return_value=True)
+    @patch('facio.vcs.git_vcs.Git.tmp_dir', return_value=True)
+    def should_detect_git_repo(self, mock_tmp_dir, mock_clone, mock_tempfile,
                                mock_stdout):
         t = Template(self.config)
-        assert not t.is_git
+        assert not t.vcs_cls
         self.config.template = 'git+git@somewhere.com:repo.git'
         t = Template(self.config)
-        self.assertEquals('Using git to clone template from '
-                          'git@somewhere.com:repo.git\n',
-                          mock_stdout.getvalue())
-        assert t.is_git
+        self.assertEquals(t.vcs_cls.__class__.__name__, 'Git')
 
     @patch('facio.template.Template.working_dir', new_callable=PropertyMock)
     def should_clone_git_repo(self, mock_working_dir):
@@ -124,8 +122,6 @@ class TemplateTests(unittest.TestCase):
         try:
             Template(self.config)
         except:
-            self.config.cli_opts.error.assert_called_with(
-                'Error cloning repository')
             assert True
         else:
             assert False


### PR DESCRIPTION
The Git Clone of a remote template is currently handled in the Template class. It would be better to decouple this from the Template class and would make it easy to support other versioning systems.
