### PR TITLE
Jinja2 File Ignore

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,6 @@ Vagrant.configure("2") do |config|
     # Port Forwarding / Assign static IP
     #
 
-    config.vm.network :forwarded_port, guest: 80, host: 8080
     config.vm.network :private_network, ip: "10.10.10.10"
 
     #

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -93,6 +93,7 @@ The ``~/.facio.cfg`` file uses ``ini`` style formatting.
     flask: git+git@github.com/my_flask_template.git
 
     [misc]
+    ignore='*.gif','./[0-9].*','?.png'
     install=0 # Experimental
 
     # Experimental
@@ -109,6 +110,9 @@ Available Options
     * **default**: Path to your custom template, prefix with ``git+`` to define git repository path.
     * **other_template**: Path to other template
 * ``[misc]``
+    * **ignore**: A comma separated list of globs which specify a pattern of
+      files to ignore, for example ``'*.gif'`` would ignore all files with a gif
+      extenstion.
     * **install**: 0 or 1 - Run ``setup.py`` to install project onto python path using ``setup.py develop``
 * ``[virtualenv]``
     * **venv_create**: 0 or 1 - Create python virtual environment

--- a/src/facio/config.py
+++ b/src/facio/config.py
@@ -180,6 +180,15 @@ class Config(object):
         except AssertionError:
             return False
 
+    @property
+    def ignore(self):
+        try:
+            globs = self.file_args.ignore
+        except AttributeError:
+            return []
+        else:
+            return globs.split(',')
+
     #
     # Python Properties (Experimental)
     #

--- a/tests/test_cfgs/ignore_files.cfg
+++ b/tests/test_cfgs/ignore_files.cfg
@@ -1,0 +1,2 @@
+[template]
+ignore='*.gif', '*.png', i_dont_need_processing.txt'

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -196,11 +196,10 @@ class TemplateTests(BaseTestCase):
             '%s.txt' % self.config.project_name)))
         rmtree(t.project_root)
 
-    @patch('facio.config.ConfigFile.path', new_callable=PropertyMock)
     @patch('facio.template.Template.working_dir', new_callable=PropertyMock)
-    def test_files_are_ignores(self, mock_working_dir, mock_cfg_path):
+    def test_files_are_ignores(self, mock_working_dir):
         mock_working_dir.return_value = tempfile.gettempdir()
-        mock_cfg_path.return_value = self._test_cfg_path('ignore_files.cfg')
+        self.config.ignore = ['*.gif', '*.png', 'i_dont_need_processing.txt']
         t = Template(self.config)
         t.copy_template()
         should_ignore = [

--- a/tests/test_template/ignore.png
+++ b/tests/test_template/ignore.png
@@ -1,0 +1,1 @@
+{{ PROJECT_NAME }}

--- a/tests/test_template/should_copy_this/i_dont_need_processing.txt
+++ b/tests/test_template/should_copy_this/i_dont_need_processing.txt
@@ -1,0 +1,1 @@
+{{ PROJECT_NAME }}

--- a/tests/test_template/should_copy_this/ignore.gif
+++ b/tests/test_template/should_copy_this/ignore.gif
@@ -1,0 +1,1 @@
+{{ PROJECT_NAME }}


### PR DESCRIPTION
Jinja2 attempts to processes all file types, should have a default set of ignore file extensions as well as command line / config option for adding more.
