### PR TITLE
choose template straight from cli

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,7 +47,8 @@ Template Options
 
 -t <ARG1>, --template=<ARG1>
             Path to your custom template, absolute paths only, git repositories can also be specified by prefixing with git+
-            for example: git+git@gitbub.com/path/to/repo.git
+            for example: git+git@gitbub.com/path/to/repo.git. This can also be the template name you gave a template in the
+            ``.facio.cfg`` file.
 
 -c, --choose_template
             If you have more than 1 template defined use this flag to override the default template, Note: specifying -t

--- a/src/facio/config.py
+++ b/src/facio/config.py
@@ -105,6 +105,11 @@ class Config(object):
     #
 
     def _validate_template_options(self):
+        templates = self.file_args.templates
+        try:
+            self._tpl = [t for n, t in templates if n == self._tpl][0]
+        except IndexError:
+            pass
         if (not self._tpl.startswith('git+') and
                 not os.path.isdir(self._tpl)):
             self._error('The path to your template does not exist.')

--- a/src/facio/config.py
+++ b/src/facio/config.py
@@ -109,7 +109,7 @@ class Config(object):
         try:
             self._tpl = [t for n, t in templates if n == self._tpl][0]
         except IndexError:
-            pass
+            pass  # We don't care if this fails, assume it's a path
         if (not self._tpl.startswith('git+') and
                 not os.path.isdir(self._tpl)):
             self._error('The path to your template does not exist.')

--- a/tests/test_cfgs/multiple_templates.cfg
+++ b/tests/test_cfgs/multiple_templates.cfg
@@ -1,3 +1,4 @@
 [template]
 default=git+git@github.com:krak3n/Facio-Default-Template.git
 another_template=/path/to/template
+foo=/path/to/template/foo

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,7 +153,7 @@ class ConfigTests(BaseTestCase):
     def test_can_refernce_template_by_name_from_cli_invalid(self, mock_path):
         mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
         try:
-            self._set_cli_args(self.base_args + ['-t', 'not_valud_name'])
+            self._set_cli_args(self.base_args + ['-t', 'not_valid_name'])
             config = Config()
         except SystemExit:
             assert True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -143,18 +143,18 @@ class ConfigTests(BaseTestCase):
     def test_can_refernce_template_by_name_from_cli(self, mock_path):
         mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
         try:
-            self._set_cli_args(self.base_args + ['-t', 'another_template'])
-            config = Config()
-            self.assertEquals(config.template, '/path/to/template')
-        except SystemExit
-            pass  # We allow a pass here because the template path is invalid
+            self._set_cli_args(self.base_args + ['-t', 'foo'])
+            self.config = Config()
+            self.assertEquals(self.config.template, '/path/to/template/foo')
+        except SystemExit:
+            assert False
 
     @patch('facio.config.ConfigFile.path', new_callable=PropertyMock)
     def test_can_refernce_template_by_name_from_cli_invalid(self, mock_path):
         mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
         try:
             self._set_cli_args(self.base_args + ['-t', 'not_valid_name'])
-            config = Config()
+            Config()
         except SystemExit:
             assert True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,6 +131,14 @@ class ConfigTests(BaseTestCase):
         except SystemExit:
             assert True
 
+    def test_value_error_raised_on_zero_template_choice(self):
+        config.input = lambda _: '0'
+        try:
+            self._set_cli_args(self.base_args + ['-c', ])
+            self.config = Config()
+        except SystemExit:
+            assert True
+
     @patch('facio.config.ConfigFile.path', new_callable=PropertyMock)
     def test_can_refernce_template_by_name_from_cli(self, mock_path):
         mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
@@ -141,11 +149,12 @@ class ConfigTests(BaseTestCase):
         except SystemExit
             pass  # We allow a pass here because the template path is invalid
 
-    def test_value_error_raised_on_zero_template_choice(self):
-        config.input = lambda _: '0'
+    @patch('facio.config.ConfigFile.path', new_callable=PropertyMock)
+    def test_can_refernce_template_by_name_from_cli_invalid(self, mock_path):
+        mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
         try:
-            self._set_cli_args(self.base_args + ['-c', ])
-            self.config = Config()
+            self._set_cli_args(self.base_args + ['-t', 'not_valud_name'])
+            config = Config()
         except SystemExit:
             assert True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,8 +139,12 @@ class ConfigTests(BaseTestCase):
         except SystemExit:
             assert True
 
+    @patch('os.path.isdir', return_value=True)
     @patch('facio.config.ConfigFile.path', new_callable=PropertyMock)
-    def test_can_refernce_template_by_name_from_cli(self, mock_path):
+    def test_can_refernce_template_by_name_from_cli(
+            self,
+            mock_path,
+            mock_isdir):
         mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
         try:
             self._set_cli_args(self.base_args + ['-t', 'foo'])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,6 +131,16 @@ class ConfigTests(BaseTestCase):
         except SystemExit:
             assert True
 
+    @patch('facio.config.ConfigFile.path', new_callable=PropertyMock)
+    def test_can_refernce_template_by_name_from_cli(self, mock_path):
+        mock_path.return_value = self._test_cfg_path('multiple_templates.cfg')
+        try:
+            self._set_cli_args(self.base_args + ['-t', 'another_template'])
+            config = Config()
+            self.assertEquals(config.template, '/path/to/template')
+        except SystemExit
+            pass  # We allow a pass here because the template path is invalid
+
     def test_value_error_raised_on_zero_template_choice(self):
         config.input = lambda _: '0'
         try:


### PR DESCRIPTION
Hi, again.

I do not really like how `-c` option behaves, right now it only allows to interactively choose template, but what would be more useful, as I think, is to allow to set desired template straight from cli, for instance:

`facio -n test -c mycooltemplate`

facio.cfg:

```
[template]
mycooltemplate=/path/to/my/really/cool/template
```

I'd written some code about 2 months ago just for myself, but after merging with your master branch my changes are not working due to massive code base change.
So I thought this time I should file an issue.

What I think is the best way in this situation is to check if `-c` argument is in defined template otherwise force user to choose from interactive prompt.

Tell me what do you think?
