### PR TITLE
Django Secret Key Pipeline

### DIFF
--- a/src/facio/config.py
+++ b/src/facio/config.py
@@ -14,7 +14,6 @@ from facio import get_version
 from facio.base import BaseFacio
 from facio.exceptions import FacioException
 from facio.state import state
-from random import choice
 from six.moves import configparser as ConfigParser
 from six.moves import input
 from textwrap import dedent
@@ -186,15 +185,3 @@ class Settings(BaseFacio):
             return []
         else:
             return globs.split(',')
-
-    @property
-    def django_secret_key(self):
-        '''Generate a secret key for Django Projects.'''
-
-        if hasattr(self, 'generated_django_secret_key'):
-            return self.generated_django_secret_key
-        else:
-            choice_str = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-            key = ''.join([choice(choice_str) for i in range(50)])
-            self.generated_django_secret_key = key
-            return key

--- a/src/facio/pipeline/__init__.py
+++ b/src/facio/pipeline/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 .. module:: facio.pipeline
    :synopsis: Pipeline detection and execution.
@@ -122,6 +124,7 @@ class Pipeline(BaseFacio):
                     e,
                     traceback.tb_lineno))
             self.calls.append({path: result})
+            state.pipeline_save_call(path, result)
             return result
 
     def has_run(self, path):
@@ -144,12 +147,10 @@ class Pipeline(BaseFacio):
         """ Run the before modules. """
 
         for path in self.pipeline.get('before', []):
-            result = self.run_module(path)
-            state.pipeline_save_call(path, result)
+            self.run_module(path)
 
     def run_after(self):
         """ Run the after modules. """
 
         for path in self.pipeline.get('after', []):
-            result = self.run_module(path)
-            state.pipeline_save_call(path, result)
+            self.run_module(path)

--- a/src/facio/pipeline/django/__init__.py
+++ b/src/facio/pipeline/django/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+"""
+.. module:: facio.pipeline.django
+   :synopsis: Pipelines for Django related templates.
+"""

--- a/src/facio/pipeline/django/secret_key.py
+++ b/src/facio/pipeline/django/secret_key.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+.. module:: facio.pipeline.django.secret_key
+   :synopsis: Generates a Django Secret key and updates context_variables with
+              a DJANGO_SECRET_KEY value.
+"""
+
+from facio.base import FacioBase
+from facio.state import state
+from random import choice
+
+
+class GenerateDjangoSecretKey(FacioBase):
+
+    characters = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
+
+    def generate(self):
+        self.out('Generating Django Secret Key')
+        key = ''.join([choice(self.characters) for i in range(50)])
+        return key
+
+
+def run():
+    """ Called by the ``facio.pipeline`` runner. """
+
+    generator = GenerateDjangoSecretKey()
+    key = generator.generate()
+    state.update_context_variables({'DJANGO_SECRET_KEY': key})
+    return key

--- a/src/facio/pipeline/django/secret_key.py
+++ b/src/facio/pipeline/django/secret_key.py
@@ -6,12 +6,12 @@
               a DJANGO_SECRET_KEY value.
 """
 
-from facio.base import FacioBase
+from facio.base import BaseFacio
 from facio.state import state
 from random import choice
 
 
-class GenerateDjangoSecretKey(FacioBase):
+class GenerateDjangoSecretKey(BaseFacio):
 
     characters = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 .. module:: tests
    :synopsis: Base test class.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -268,7 +268,7 @@ class PipelineTest(BaseTestCase):
         p.run_module('foo.bar.baz')
         self.assertTrue(module.foo.called)
         self.mocked_facio_pipeline_Pipeline_warning.assert_called_with(
-            'Exeption caught in module: \'Failed lookup\' line: 115')
+            'Exeption caught in module: \'Failed lookup\' line: 117')
         mock = import_module_mock.stop()
 
     @patch('facio.pipeline.Pipeline.load', return_value=True)

--- a/tests/test_pipelines/__init__.py
+++ b/tests/test_pipelines/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+"""
+.. module:: tests.test_pipeline
+   :synopsis: Tests for bundled pipelines
+"""

--- a/tests/test_pipelines/test_django.py
+++ b/tests/test_pipelines/test_django.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+"""
+.. module:: tests.test_pipeline.test_django
+   :synopsis: Tests for bundled django pipelines
+"""
+
+
+from facio.pipeline.django.secret_key import GenerateDjangoSecretKey, run
+from facio.state import state
+from mock import patch
+from six.moves import builtins
+
+from .. import BaseTestCase
+
+
+class TestDjangoSecretKey(BaseTestCase):
+
+    def setUp(self):
+        self._patch_clint([
+            'facio.base.puts',
+            'facio.pipeline.django.secret_key.GenerateDjangoSecretKey.out',
+        ])
+
+    def tearDown(self):
+        try:
+            del(builtins.__facio__)
+        except AttributeError:
+            pass
+
+    @patch('facio.pipeline.django.secret_key.choice', create=True)
+    @patch('facio.pipeline.django.secret_key.range', create=True)
+    def test_generate_key(self, mock_range, mock_choice):
+        mock_range.return_value = [0, ]
+        mock_choice.return_value = 'a'
+
+        i = GenerateDjangoSecretKey()
+        key = i.generate()
+
+        self.assertEqual(key, 'a')
+        self.mocked_facio_pipeline_django_secret_key_GenerateDjangoSecretKey_out.assert_called_with('Generating Django Secret Key')  # NOQA
+
+    @patch('facio.pipeline.django.secret_key.GenerateDjangoSecretKey.generate')
+    def test_run(self, mock_generate):
+        mock_generate.return_value = 'foobarbaz'
+
+        key = run()
+
+        self.assertEqual(key, 'foobarbaz')
+        self.assertEqual(state.context_variables['DJANGO_SECRET_KEY'],
+                         'foobarbaz')


### PR DESCRIPTION
Move the Django Secret Key Generation to a pipeline - should be a pre only pipeline so it can be used in templates.
